### PR TITLE
Issue/15 store ISO instead of Unix timestamp #minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Service listening for submission objects via an API endpoint and saving them to 
 You can quickly build & serve the app using the following commands
 
 ```
-cd .\src
 docker build ./src/flamflam.SubmissionService -t submission-service-image
 docker run -it --rm -p 5000:80 submission-service-image
 ```

--- a/src/flamflam.SubmissionService/Models/Submission.cs
+++ b/src/flamflam.SubmissionService/Models/Submission.cs
@@ -12,6 +12,6 @@ namespace flamflam.SubmissionService.Models
 
         [Required]
         [JsonProperty("created_utc")]
-        public DateTimeOffset? CreatedUtc { get; set; }
+        public DateTime? CreatedUtc { get; set; }
     }
 }

--- a/src/flamflam.SubmissionService/Models/Submission.cs
+++ b/src/flamflam.SubmissionService/Models/Submission.cs
@@ -13,29 +13,5 @@ namespace flamflam.SubmissionService.Models
         [Required]
         [JsonProperty("created_utc")]
         public DateTime? CreatedUtc { get; set; }
-
-        [Required]
-        [JsonProperty("author")]
-        public string? Author { get; set; }
-
-        [Required]
-        [JsonProperty("title")]
-        public string? Title { get; set; }
-
-        [Required]
-        [JsonProperty("selftext")]
-        public string? SelfText { get; set; }
-
-        [Required]
-        [JsonProperty("score")]
-        public int? Score { get; set; }
-
-        [Required]
-        [JsonProperty("upvote_ratio")]
-        public int? UpvoteRatio { get; set; }
-
-        [Required]
-        [JsonProperty("comment_count")]
-        public int? CommentCount { get; set; }
     }
 }


### PR DESCRIPTION
<!-- Write a description here -->
Use ISO timestamp for CreatedAt field from the dispatcher. Even though  Reddit API returns Unix timestamps, ISO is more use friendly.

<!-- Which issue is this PR resolving -->
Closes #15

## Changes made
- Readme update after a test
- Submission type update

## Notes for the reviewer
- `dotnet test` succeeded
- `make docker-up` logs confirmed ok

## Checklist
- [x] Correct version increment expected (`#patch`/`#minor`/`#major`)
- [ ] Tests updated _(if applicable)_
- [x] Docs updated _(if applicable)_
