### PR TITLE
Revert "flam-flam/dispatcher-service#21 add more fields"

### DIFF
--- a/src/flamflam.SubmissionService/Models/Submission.cs
+++ b/src/flamflam.SubmissionService/Models/Submission.cs
@@ -13,29 +13,5 @@ namespace flamflam.SubmissionService.Models
         [Required]
         [JsonProperty("created_utc")]
         public DateTimeOffset? CreatedUtc { get; set; }
-
-        [Required]
-        [JsonProperty("author")]
-        public string? Author { get; set; }
-
-        [Required]
-        [JsonProperty("title")]
-        public string? Title { get; set; }
-
-        [Required]
-        [JsonProperty("selftext")]
-        public string? SelfText { get; set; }
-
-        [Required]
-        [JsonProperty("score")]
-        public int? Score { get; set; }
-
-        [Required]
-        [JsonProperty("upvote_ratio")]
-        public int? UpvoteRatio { get; set; }
-
-        [Required]
-        [JsonProperty("comment_count")]
-        public int? CommentCount { get; set; }
     }
 }


### PR DESCRIPTION
<!-- Write a description here -->
Use ISO timestamp for CreatedAt field from the dispatcher. Even though  Reddit API returns Unix timestamps, ISO is more use friendly.

<!-- Which issue is this PR resolving -->
Closes #15

## Changes made
- Readme update after a test
- Submission type update

## Notes for the reviewer
- `dotnet test` succeeded
- `make docker-up` logs confirmed ok

## Checklist
- [x] Correct version increment expected (`#patch`/`#minor`/`#major`)
- [ ] Tests updated _(if applicable)_
- [x] Docs updated _(if applicable)_
